### PR TITLE
refactor: Remove 'Hito' branding from UI

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,8 +15,8 @@ const geistMono = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Hito",
-  description: "Hito - chatbot",
+  title: "Chatbot",
+  description: "Chatbot",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -221,7 +221,7 @@ export default function Component() {
           isVisible ? "opacity-100" : "opacity-0"
         }`}
       >
-        Chatbot Ventas HITO{" "}
+        Chatbot Ventas{" "}
         <span className="relative inline-flex items-center justify-center ml-2">
           <svg className="absolute w-full h-full" viewBox="0 -5 100 50">
             <defs>


### PR DESCRIPTION
Removes the word 'Hito' from the browser tab title and the main heading on the page, as requested by the user.